### PR TITLE
Explicit Python version suport

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ ChangeLog
 1.0.5 (unreleased)
 ------------------
 
-* Not yet.
+* Explicit Python 3.4 and 3.5 support in setup.py and README.
 
 1.0.4 (2018-11-16)
 ------------------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Secrets backport
 
-Backported python3 [secrets](https://hg.python.org/cpython/file/3.6/Lib/secrets.py) module for python2.7
+Backport of Python 3.6's [secrets](https://docs.python.org/3/library/secrets.html) module for Python 2.7, 3.4 and 3.5.
 

--- a/setup.py
+++ b/setup.py
@@ -37,14 +37,11 @@ setup(
     version=get_version(),
     description='Backport of secrets for python2',
     long_description=get_long_description(),
-
     author='Scaleway',
     author_email='opensource@scaleway.com',
     url='https://github.com/scaleway/python2-secrets',
     packages=find_packages(),
-    python_requires='>= 2.7, != 3.*.*',
-    dependency_links=[
-    ],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     test_suite=MODULE_NAME + '.tests',
     classifiers=[
         # See: https://pypi.python.org/pypi?:action=list_classifiers
@@ -57,8 +54,12 @@ setup(
         # https://en.wikipedia.org/wiki/CPython#Version_history
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
This backport supports Python3 < 3.6 but the setup.py didn't reflect that correctly.